### PR TITLE
Update Makefile copy routines post-pdm-gen

### DIFF
--- a/user_data_model/Makefile
+++ b/user_data_model/Makefile
@@ -73,12 +73,13 @@ build-pdm:
 # install our example data model into the system
 install-pdm:
 	cp pdm/lib* $(PSYNC_HOME)/lib/
-	cp pdm/*.h $(PSYNC_HOME)/include
-	cp pdm/*.hpp $(PSYNC_HOME/include
 
 # install to system
 install: all
 	cp $(TARGET) $(PSYNC_HOME)/bin/
+	cp pdm/*.so $(PSYNC_HOME)/lib/
+	cp pdm/*.h $(PSYNC_HOME)/include/
+	cp pdm/*.hpp $(PSYNC_HOME/include/
 
 #
 clean:

--- a/user_data_model/Makefile
+++ b/user_data_model/Makefile
@@ -73,6 +73,8 @@ build-pdm:
 # install our example data model into the system
 install-pdm:
 	cp pdm/lib* $(PSYNC_HOME)/lib/
+	cp pdm/*.h $(PSYNC_HOME)/pdm/
+	cp pdm/*.hpp $(PSYNC_HOME)/pdm/
 
 # install to system
 install: all

--- a/user_data_model/Makefile
+++ b/user_data_model/Makefile
@@ -73,7 +73,8 @@ build-pdm:
 # install our example data model into the system
 install-pdm:
 	cp pdm/lib* $(PSYNC_HOME)/lib/
-	cp pdm/*.h $(PSYNC_HOME)/pdm/
+	cp pdm/*.h $(PSYNC_HOME)/include
+	cp pdm/*.hpp $(PSYNC_HOME/include
 
 # install to system
 install: all

--- a/user_data_model/Makefile
+++ b/user_data_model/Makefile
@@ -72,7 +72,7 @@ build-pdm:
 
 # install our example data model into the system
 install-pdm:
-	cp pdm/lib* $(PSYNC_HOME)/lib/
+	cp pdm/*.so $(PSYNC_HOME)/lib/
 	cp pdm/*.h $(PSYNC_HOME)/pdm/
 	cp pdm/*.hpp $(PSYNC_HOME)/pdm/
 


### PR DESCRIPTION
After pdm-gen is run, all the *.so, and *.h / *.hpp files need to be copied to the lib/ and include/ directories respectfully.
