### PR TITLE
Add two examples to the C API repo

### DIFF
--- a/logfile_iterator_for_velodyne/Makefile
+++ b/logfile_iterator_for_velodyne/Makefile
@@ -1,0 +1,68 @@
+##########################################################
+# makefile for logfile-iterator-for-velodyne
+##########################################################
+
+
+# source PolySync environment if not already done, assumes x86_64 if set here
+# usually, the environment has these set
+PSYNC_HOME ?= /usr/local/polysync
+OSPL_HOME ?= $(PSYNC_HOME)/utils/x86_64.linux
+
+# target
+TARGET	:= bin/polysync-logfile-iterator-for-velodyne-c
+
+# sources
+SRCS    :=  src/logfile_iterator_for_velodyne.c
+
+# object files, dep files
+OBJS    := $(SRCS:.c=.o)
+DEPS    := $(SRCS:.c=.dep)
+XDEPS   := $(wildcard $(DEPS))
+
+# get standard PolySync build resources
+include $(PSYNC_HOME)/build_res.mk
+
+#
+INCLUDE += -Iinclude
+
+# compiler
+CC = gcc
+
+# add data model library
+LIBS += -lpolysync_data_model
+
+#
+all: dirs $(TARGET)
+
+#
+ifneq ($(XDEPS),)
+include $(XDEPS)
+endif
+
+# directories
+dirs::
+	mkdir -p bin
+
+#
+$(TARGET): $(OBJS)
+	$(CC) $(LDFLAGS) $(INCLUDE) -o $@ $^ $(LIBS)
+
+#
+$(OBJS): %.o: %.c %.dep
+	$(CC) $(CCFLAGS) $(INCLUDE) -o $@ -c $<
+
+#
+$(DEPS): %.dep: %.c Makefile
+	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
+
+# install to system
+install: all
+	cp $(TARGET) $(PSYNC_HOME)/bin/
+
+#
+clean:
+	-rm -f src/*.o
+	-rm -f src/*.dep
+	-rm -f $(TARGET)
+	-rm -f bin/*
+	-rm -rf ospl-*.log

--- a/logfile_iterator_for_velodyne/include/velodyne_hdl_driver.h
+++ b/logfile_iterator_for_velodyne/include/velodyne_hdl_driver.h
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) 2016 PolySync
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * @file velodyne_hdl_driver.h
+ * @brief Velodyne HDL Hardware Driver.
+ *
+ * All native multi-byte values are little endian unless specified otherwise.
+ *
+ * Default UDP data port is 2368, web interface on port 80.
+ * Default IP is 192.168.2.202.
+ *
+ * Uses the name space 'VELO' to shorthand the key word 'VELODYNE' on macros.
+ *
+ * PUBLIC_HEADER
+ */
+
+
+
+
+#ifndef VELODYNE_HDL_DRIVER_H
+#define	VELODYNE_HDL_DRIVER_H
+
+
+
+
+#include <inttypes.h>
+
+#include "polysync_core.h"
+#include "polysync_socket.h"
+
+
+
+
+/**
+ * @brief Default Velodyne HDL Ethernet UDP port number. [int]
+ *
+ */
+#define VELO_HDL_DEFAULT_UDP_PORT (2368)
+
+
+/**
+ * @brief Maximum total size of Velodyne HDL message. [bytes]
+ *
+ */
+#define VELO_HDL_MESSAGE_MAX_SIZE (1206)
+
+
+/**
+ * @brief Maximum detection range. [meters]
+ *
+ */
+#define VELO_HDL32_MAX_RANGE (120.0)
+
+
+/**
+ * @brief Number of rotational increments. [1/100 degrees/bit]
+ *
+ */
+#define VELO_HDL_ROTATION_ANGLE_COUNT (36000)
+
+
+/**
+ * @brief Maximum number of vertical lasers supported. [uint32_t]
+ *
+ */
+#define VELO_HDL_LASERS_MAX (64)
+
+
+/**
+ * @brief Number of lasers in the Velodyne HDL32E. [uint32_t]
+ *
+ */
+#define VELO_HDL32E_LASER_COUNT (32)
+
+
+/**
+ * @brief Number of \ref velodyne_hdl_laser_return_s structures in a \ref velodyne_hdl_firing_data_s structure. [uint32_t]
+ *
+ */
+#define VELO_HDL_LASER_PER_FIRING (32)
+
+
+/**
+ * @brief Number of Velodyne HDL32E \ref velodyne_hdl_firing_data_s structures in a \ref velodyne_hdl_message_s structure. [uint32_t]
+ *
+ */
+#define VELO_HDL32E_FIRING_PER_MESSAGE (12)
+
+
+/**
+ * @brief Block identifier value indicating data is in the 0-31 range. [uint16_t]
+ *
+ * Start offset in the laser return data and validate firing data.
+ *
+ * Valid block identifier value.
+ *
+ */
+#define VELO_HDL_BLOCK_ID_0_TO_31 (0xEEFF)
+
+
+/**
+ * @brief Block identifier value indicating data is in the 32-63 range. [uint16_t]
+ *
+ * Used to offset the laser return data and validate firing data.
+ *
+ * Valid block identifier value.
+ *
+ */
+#define VELO_HDL_BLOCK_ID_32_TO_63 (0xDDFF)
+
+
+/**
+ * @brief Invalid \ref velodyne_hdl_laser_return_s.distance value. [uint16_t]
+ *
+ * Means no return within maximum range or invalid return.
+ *
+ */
+#define VELO_HDL_LASER_RETURN_DISTANCE_INVALID (0x0000)
+
+
+/**
+ * @brief Lowest \ref velodyne_hdl_laser_return_s.intensity value. [uint8_t]
+ *
+ * Lowest return energy.
+ *
+ */
+#define VELO_HDL_LASER_RETURN_INTENSITY_MIN (0x00)
+
+
+/**
+ * @brief Highest \ref velodyne_hdl_laser_return_s.intensity value. [uint8_t]
+ *
+ * Highest return energy.
+ *
+ */
+#define VELO_HDL_LASER_RETURN_INTENSITY_MAX (0xFF)
+
+
+/**
+ * @brief Convert uint16_t rotational position to double angle. [degrees]
+ *
+ */
+#define VELO_HDL32E_ROTATION_TO_ANGLE( mangle ) ((((double) mangle) / 100.0))
+
+
+/**
+ * @brief Number of rotation units per degree. [uint16_t]
+ *
+ */
+#define VELO_HDL32E_ROTATION_PER_DEGREE (100)
+
+
+/**
+ * @brief Convert uint16_t return distance to double. [meters]
+ *
+ */
+#define VELO_HDL32E_DISTANCE_TO_METER( mrange ) ((((double) mrange) * 0.002))
+
+
+
+
+// enforce 1 byte alignment so we can do linear packing
+#pragma pack(push)
+#pragma pack(1)
+
+
+/**
+ * @brief Velodyne HDL laser return data.
+ *
+ * Provides laser return distance and intensity information.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    uint16_t distance; /*!< Distance.
+                        * Value \ref VELO_HDL_LASER_RETURN_DISTANCE_INVALID means invalid laser return. [2 millimeters/bit] */
+    //
+    //
+    uint8_t intensity; /*!< Intensity. See \ref VELO_HDL_LASER_RETURN_INTENSITY_MIN and \ref VELO_HDL_LASER_RETURN_INTENSITY_MAX. */
+} velodyne_hdl_laser_return_s;
+
+
+/**
+ * @brief Velodyne HDL firing data.
+ *
+ * Provides a block of vertical laser return information for a rotation angle.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    uint16_t block_id; /*!< Block idetifier. Identifies the information block.
+                        * See \ref VELO_HDL_BLOCK_ID_0_TO_31 and \ref VELO_HDL_BLOCK_ID_32_TO_63 for valid values. */
+    //
+    //
+    uint16_t rotational_pos; /*!< Rotation angle. [1/100 degrees/bit] */
+    //
+    //
+    velodyne_hdl_laser_return_s laser_returns[VELO_HDL_LASER_PER_FIRING]; /*!< Laser returns. */
+} velodyne_hdl_firing_data_s;
+
+
+
+/**
+ * @brief Velodyne HDL message data.
+ *
+ * Provides a list of firing data blocks and timing information.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    velodyne_hdl_firing_data_s firing_data[VELO_HDL32E_FIRING_PER_MESSAGE]; /*!< Firing data blocks. */
+    //
+    //
+    uint32_t gps_timestamp; /*!< GPS synchronized timestamp. Time since the top of the hour. [microseconds] */
+    //
+    //
+    uint8_t reserved_0; /*!< Reserved data. */
+    //
+    //
+    uint8_t reserved_1; /*!< Reserved data. */
+} velodyne_hdl_message_s;
+
+
+// restore alignment
+#pragma pack(pop)
+
+
+/**
+ * @brief Velodyne HDL32E laser correction data.
+ *
+ * Contains pre-calculated laser correction data.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    double azimuth; /*!< Azimuth. */
+    //
+    //
+    double vertical; /*!< Vertical. [degrees] */
+    //
+    //
+    double distance; /*!< Distance. */
+    //
+    //
+    double vertical_offset; /*!< Vertical offset. */
+    //
+    //
+    double horizontal_offset; /*!< Horizontal offset. */
+    //
+    //
+    double sin_vertical; /*!< Sine vertical. */
+    //
+    //
+    double cos_vertical; /*!< Cosine vertical. */
+    //
+    //
+    double sin_vertical_offset; /*!< Sine vertical offset. */
+    //
+    //
+    double cos_vertical_offset; /*!< Cosine vertical offset. */
+} velodyne_hdl32e_laser_correction_s;
+
+
+/**
+ * @brief Velodyne HDL32E corrections data.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    velodyne_hdl32e_laser_correction_s laser_corrections[VELO_HDL_LASERS_MAX]; /*!< Correction for each laser. */
+    //
+    //
+    double cos_table[VELO_HDL_ROTATION_ANGLE_COUNT]; /*!< Lookup table for cosine(rotational_position) . */
+    //
+    //
+    double sin_table[VELO_HDL_ROTATION_ANGLE_COUNT]; /*!< Lookup table for sine(rotational_position) . */
+} velodyne_hdl32e_corrections_s;
+
+
+
+
+/**
+ * @brief Initialize Velodyne HDL32E corrections data using an array of vertical corrections.
+ *
+ * @param [in] laser_vertical_corrections A pointer to double which specifies the input vertical corrections array.
+ * @param [in] num_lasers Number of vertical corrections/lasers in the provided array.
+ * @param [out] corrections A pointer to \ref velodyne_hdl32e_corrections_s which receives the initialization.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ *
+ */
+int velodyne_hdl32e_init_corrections(
+        const double * const laser_vertical_corrections,
+        const unsigned long num_lasers,
+        velodyne_hdl32e_corrections_s * const corrections );
+
+
+/**
+ * @brief Configure UDP socket for Velodyne HDL device communication.
+ *
+ * @note Expects a valid TCP socket, created by the user.
+ *
+ * @note Sets the non-blocking IO socket option.
+ *
+ * @param [in] sock A pointer to \ref ps_socket which receives the configuration.
+ * @param [in] address A pointer to char buffer which specifies the device IP address.
+ * Value \ref PSYNC_SOCKET_ADDRESS_ANY is acceptable but not recommended.
+ * @parm [in] port Port number to bind the socket to.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if success.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_CONFIG if socket/configuration is invalid.
+ *
+ */
+int velodyne_hdl_configure_socket(
+        ps_socket * const sock,
+        const char * const address,
+        const unsigned long port );
+
+
+/**
+ * @brief Check if byte buffer is a valid Velodyne HDL message.
+ *
+ * Checks for a valid buffer size.
+ *
+ * @param [in] buffer A pointer to char buffer which receives the validation.
+ * @param [in] buffer_len Number of bytes in the buffer. [bytes]
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_DATAERR if message is invalid.
+ *
+ */
+int velodyne_hdl_is_message_valid(
+        const unsigned char * const buffer,
+        const unsigned long buffer_len );
+
+
+/**
+ * @brief Check if data is a valid Velodyne HDL firing data.
+ *
+ * Checks for a valid block ID and firing rotation position.
+ *
+ * @param [in] firing_data A pointer to \ref velodyne_hdl_firing_data_s which receives the validation.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_DATAERR if data is invalid.
+ *
+ */
+int velodyne_hdl_is_firing_data_valid(
+        const velodyne_hdl_firing_data_s * const firing_data );
+
+
+/**
+ * @brief Check if data is a valid Velodyne HDL laser return.
+ *
+ * Checks for a valid return distance.
+ *
+ * @param [in] laser_return A pointer to \ref velodyne_hdl_laser_return_s which receives the validation.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_DATAERR if data is invalid.
+ *
+ */
+int velodyne_hdl_is_laser_return_valid(
+        const velodyne_hdl_laser_return_s * const laser_return );
+
+
+/**
+ * @brief Poll for an available valid Velodyne HDL message.
+ *
+ * Calls \ref velodyne_hdl_is_message_valid if a frame was received.
+ *
+ * @param [in] sock A pointer to \ref ps_socket which holds the configuration.
+ * @param [out] buffer A pointer to unsigned char buffer which receives the data read.
+ * @param [in] buffer_len Length of provided buffer.
+ * @param [out] bytes_read A pointer to unsigned long which receives the count value.
+ * @param [out] timestamp A pointer to \ref ps_timestamp which receives the receive timestamp value.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_UNAVAILABLE if timeout expired and/or no message available when in non-blocking mode (see \ref psync_socket_recv_from).
+ * \li \ref DTC_DATAERR if frame is invalid.
+ *
+ */
+int velodyne_hdl_read_message(
+        ps_socket * const sock,
+        unsigned char * const buffer,
+        const unsigned long buffer_len,
+        unsigned long * const bytes_read,
+        ps_timestamp * const timestamp );
+
+
+
+
+#endif	/* VELODYNE_HDL_DRIVER_H */

--- a/logfile_iterator_for_velodyne/src/logfile_iterator_for_velodyne.c
+++ b/logfile_iterator_for_velodyne/src/logfile_iterator_for_velodyne.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2016 PolySync
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * \example logfile_iterator_for_velodyne_hdl.c
+ *
+ * Shows how to use the Logfile API routines to iterate over a Velodyne HDL
+ * PolySync logfile and access the raw data, outside the normal replay time domain.
+ *
+ */
+
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
+
+// API headers
+#include "polysync_core.h"
+#include "polysync_sdf.h"
+#include "polysync_node.h"
+#include "polysync_message.h"
+#include "polysync_logfile.h"
+
+#include "velodyne_hdl_driver.h"
+
+
+
+// *****************************************************
+// static global types/macros
+// *****************************************************
+
+/**
+ * @brief PolySync node name.
+ *
+ */
+static const char NODE_NAME[] = "polysync-logfile-iterator-c";
+
+
+/**
+ * @brief Logfile path we'll use instead of the automatic API-generated name.
+ * 
+ * This is the path to the sample logfile session that's shipped with the release
+ *
+ */
+static const char LOGFILE_PATH[] = "/usr/local/polysync/rnr_logs/1000/velodyne-hdl32e.1688883498343430.plog";
+
+
+/**
+ * @brief PolySync 'ps_byte_array_msg' type name.
+ *
+ */
+static const char BYTE_ARRAY_MSG_NAME[] = "ps_byte_array_msg";
+
+
+/**
+ * @brief Structure to store the byte array message type
+ *
+ */
+typedef struct
+{
+    //
+    // node reference
+    ps_node_ref node_ref;
+    //
+    // message type for 'ps_byte_array_msg'
+    ps_msg_type byte_array_msg_type;
+    //
+    //
+    char in_file[PSYNC_DEFAULT_STRING_LEN];
+    //
+    //
+    char out_file[PSYNC_DEFAULT_STRING_LEN];
+} context_s;
+
+
+
+
+// *****************************************************
+// static declarations
+// *****************************************************
+
+/**
+ * @brief Logfile iterator callback.
+ *
+ * @warning When logfile is empty, expect:
+ * \li \ref ps_logfile_attributes.data_count == 0
+ * \li msg_type == \ref PSYNC_MSG_TYPE_INVALID
+ * \li log_record == NULL
+ *
+ * @param [in] file_attributes Logfile attributes loaded by the logfile API.
+ * @param [in] msg_type Message type identifier for the message in \ref ps_rnr_log_record.data, as seen by this data model.
+ * @param [in] log_record Logfile record loaded by the logfile API.
+ * @param [in] user_data A pointer to user data, provided by \ref psync_logfile_foreach_iterator.
+ *
+ */
+static void logfile_iterator_callback(
+        const ps_logfile_attributes * const file_attributes,
+        const ps_msg_type msg_type,
+        const ps_rnr_log_record * const log_record,
+        void * const user_data );
+
+
+
+
+// *****************************************************
+// static definitions
+// *****************************************************
+
+//
+static void logfile_iterator_callback(
+        const ps_logfile_attributes * const file_attributes,
+        const ps_msg_type msg_type,
+        const ps_rnr_log_record * const log_record,
+        void * const user_data )
+{
+
+
+    context_s * const context = (context_s*) user_data;
+
+    // if logfile is empty, only attributes are provided
+    if( log_record != NULL )
+    {
+        printf( "log record - index: %lu - size: %lu bytes - prev_size: %lu bytes - RnR timestamp (header.timestamp): %llu\n",
+            (unsigned long) log_record->index,
+            (unsigned long) log_record->size,
+            (unsigned long) log_record->prev_size,
+            (unsigned long long) log_record->timestamp );
+        
+        // we only want to read byte array messages, where the sensors payload 
+        // is typically stored
+        if( msg_type == context->byte_array_msg_type )
+        {
+        
+            // get the PolySync message reference
+            const ps_msg_ref msg = (ps_msg_ref) log_record->data;
+            //
+            const ps_byte_array_msg * const byte_array_msg = (ps_byte_array_msg*) msg;
+            
+            // here you have access to the data, as it's stored within 
+            // the data structures of the file `include/velodyne_hdl_driver.h`
+            // all you need to do is cast to the structure
+            
+            const velodyne_hdl_message_s * const velodyne_packet = (velodyne_hdl_message_s*) byte_array_msg->bytes._buffer;
+            
+            // here you have access to the data, as it's stored within 
+            // the data structures of the include/velodyne_hdl_driver.h
+            
+            printf("Some packets distance: %d\n", velodyne_packet->firing_data[0].laser_returns[0].intensity );
+            
+        }
+    }
+
+    printf( "\n" );
+}
+
+
+
+
+// *****************************************************
+// main
+// *****************************************************
+int main( int argc, char **argv )
+{
+    // polysync return status
+    int ret = DTC_NONE;
+    
+    // context data
+    context_s context; 
+    
+    memset( &context, 0, sizeof(context) );
+    
+                            printf("stuff\n");
+
+
+    // init core API
+    if( (ret = psync_init(
+            NODE_NAME,
+            PSYNC_NODE_TYPE_API_USER,
+            PSYNC_DEFAULT_DOMAIN,
+            PSYNC_SDF_ID_INVALID,
+            PSYNC_INIT_FLAG_STDOUT_LOGGING,
+            &context.node_ref )) != DTC_NONE )
+    {
+        psync_log_message(
+                LOG_LEVEL_ERROR,
+                "main -- psync_init - ret: %d",
+                ret );
+        return EXIT_FAILURE;
+    }
+    
+     // get the message type for 'ps_byte_array_msg'
+    ret = psync_message_get_type_by_name(
+            context.node_ref,
+            BYTE_ARRAY_MSG_NAME,
+            &context.byte_array_msg_type );
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_message_get_type_by_name - ret: %d", ret );
+        (void) psync_release( &context.node_ref );
+        return EXIT_FAILURE;
+    }
+
+    // initialize logfile API resources
+    if( (ret = psync_logfile_init( context.node_ref )) != DTC_NONE )
+    {
+        psync_log_message(
+                LOG_LEVEL_ERROR,
+                "main -- psync_logfile_init - ret: %d",
+                ret );
+        goto GRACEFUL_EXIT_STMNT;
+    }
+
+    // iterate over the logfile data
+    if( (ret = psync_logfile_foreach_iterator(
+            context.node_ref,
+            LOGFILE_PATH,
+            logfile_iterator_callback,
+            &context )) != DTC_NONE )
+    {
+        psync_log_message(
+                LOG_LEVEL_ERROR,
+                "main -- psync_logfile_foreach_iterator - ret: %d",
+                ret );
+        goto GRACEFUL_EXIT_STMNT;
+    }
+
+    // using 'goto' to allow for an easy example exit
+    GRACEFUL_EXIT_STMNT:
+
+    // release logfile API resources
+    if( (ret = psync_logfile_release( context.node_ref )) != DTC_NONE )
+    {
+        psync_log_message(
+                LOG_LEVEL_ERROR,
+                "main -- psync_logfile_release - ret: %d",
+                ret );
+    }
+
+	// release core API
+    if( (ret = psync_release( &context.node_ref )) != DTC_NONE )
+    {
+        psync_log_message(
+                LOG_LEVEL_ERROR,
+                "main -- psync_release - ret: %d",
+                ret );
+    }
+
+
+	return EXIT_SUCCESS;
+}

--- a/logfile_to_pcap_convertor/Makefile
+++ b/logfile_to_pcap_convertor/Makefile
@@ -1,0 +1,68 @@
+##########################################################
+# makefile for logfile-to-pcap-convertor
+##########################################################
+
+
+# source PolySync environment if not already done, assumes x86_64 if set here
+# usually, the environment has these set
+PSYNC_HOME ?= /usr/local/polysync
+OSPL_HOME ?= $(PSYNC_HOME)/utils/x86_64.linux
+
+# target
+TARGET	:= bin/polysync-logfile-to-pcap-convertor-c
+
+# sources
+SRCS    :=  src/logfile_to_pcap_convertor.c
+
+# object files, dep files
+OBJS    := $(SRCS:.c=.o)
+DEPS    := $(SRCS:.c=.dep)
+XDEPS   := $(wildcard $(DEPS))
+
+# get standard PolySync build resources
+include $(PSYNC_HOME)/build_res.mk
+
+# compiler
+CC = gcc
+
+#
+INCLUDE += -Iinclude
+
+# add data model library
+LIBS += -lpolysync_data_model -lpcap
+
+#
+all: dirs $(TARGET)
+
+#
+ifneq ($(XDEPS),)
+include $(XDEPS)
+endif
+
+# directories
+dirs::
+	mkdir -p bin
+
+#
+$(TARGET): $(OBJS)
+	$(CC) $(LDFLAGS) $(INCLUDE) -o $@ $^ $(LIBS)
+
+#
+$(OBJS): %.o: %.c %.dep
+	$(CC) $(CCFLAGS) $(INCLUDE) -o $@ -c $<
+
+#
+$(DEPS): %.dep: %.c Makefile
+	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
+
+# install to system
+install: all
+	cp $(TARGET) $(PSYNC_HOME)/bin/
+
+#
+clean:
+	-rm -f src/*.o
+	-rm -f src/*.dep
+	-rm -f $(TARGET)
+	-rm -f bin/*
+	-rm -rf ospl-*.log

--- a/logfile_to_pcap_convertor/include/velodyne_hdl_driver.h
+++ b/logfile_to_pcap_convertor/include/velodyne_hdl_driver.h
@@ -1,0 +1,413 @@
+/**
+ * @file velodyne_hdl_driver.h
+ * @brief Velodyne HDL Hardware Driver.
+ *
+ * All native multi-byte values are little endian unless specified otherwise.
+ *
+ * Default UDP data port is 2368, web interface on port 80.
+ * Default IP is 192.168.2.202.
+ *
+ * Uses the name space 'VELO' to shorthand the key word 'VELODYNE' on macros.
+ *
+ * PUBLIC_HEADER
+ */
+
+
+
+
+#ifndef VELODYNE_HDL_DRIVER_H
+#define	VELODYNE_HDL_DRIVER_H
+
+
+
+
+#include <inttypes.h>
+
+#include "polysync_core.h"
+#include "polysync_socket.h"
+
+
+
+
+/**
+ * @brief Default Velodyne HDL Ethernet UDP port number. [int]
+ *
+ */
+#define VELO_HDL_DEFAULT_UDP_PORT (2368)
+
+
+/**
+ * @brief Maximum total size of Velodyne HDL message. [bytes]
+ *
+ */
+#define VELO_HDL_MESSAGE_MAX_SIZE (1206)
+
+
+/**
+ * @brief Maximum detection range. [meters]
+ *
+ */
+#define VELO_HDL32_MAX_RANGE (120.0)
+
+
+/**
+ * @brief Number of rotational increments. [1/100 degrees/bit]
+ *
+ */
+#define VELO_HDL_ROTATION_ANGLE_COUNT (36000)
+
+
+/**
+ * @brief Maximum number of vertical lasers supported. [uint32_t]
+ *
+ */
+#define VELO_HDL_LASERS_MAX (64)
+
+
+/**
+ * @brief Number of lasers in the Velodyne HDL32E. [uint32_t]
+ *
+ */
+#define VELO_HDL32E_LASER_COUNT (32)
+
+
+/**
+ * @brief Number of \ref velodyne_hdl_laser_return_s structures in a \ref velodyne_hdl_firing_data_s structure. [uint32_t]
+ *
+ */
+#define VELO_HDL_LASER_PER_FIRING (32)
+
+
+/**
+ * @brief Number of Velodyne HDL32E \ref velodyne_hdl_firing_data_s structures in a \ref velodyne_hdl_message_s structure. [uint32_t]
+ *
+ */
+#define VELO_HDL32E_FIRING_PER_MESSAGE (12)
+
+
+/**
+ * @brief Block identifier value indicating data is in the 0-31 range. [uint16_t]
+ *
+ * Start offset in the laser return data and validate firing data.
+ *
+ * Valid block identifier value.
+ *
+ */
+#define VELO_HDL_BLOCK_ID_0_TO_31 (0xEEFF)
+
+
+/**
+ * @brief Block identifier value indicating data is in the 32-63 range. [uint16_t]
+ *
+ * Used to offset the laser return data and validate firing data.
+ *
+ * Valid block identifier value.
+ *
+ */
+#define VELO_HDL_BLOCK_ID_32_TO_63 (0xDDFF)
+
+
+/**
+ * @brief Invalid \ref velodyne_hdl_laser_return_s.distance value. [uint16_t]
+ *
+ * Means no return within maximum range or invalid return.
+ *
+ */
+#define VELO_HDL_LASER_RETURN_DISTANCE_INVALID (0x0000)
+
+
+/**
+ * @brief Lowest \ref velodyne_hdl_laser_return_s.intensity value. [uint8_t]
+ *
+ * Lowest return energy.
+ *
+ */
+#define VELO_HDL_LASER_RETURN_INTENSITY_MIN (0x00)
+
+
+/**
+ * @brief Highest \ref velodyne_hdl_laser_return_s.intensity value. [uint8_t]
+ *
+ * Highest return energy.
+ *
+ */
+#define VELO_HDL_LASER_RETURN_INTENSITY_MAX (0xFF)
+
+
+/**
+ * @brief Convert uint16_t rotational position to double angle. [degrees]
+ *
+ */
+#define VELO_HDL32E_ROTATION_TO_ANGLE( mangle ) ((((double) mangle) / 100.0))
+
+
+/**
+ * @brief Number of rotation units per degree. [uint16_t]
+ *
+ */
+#define VELO_HDL32E_ROTATION_PER_DEGREE (100)
+
+
+/**
+ * @brief Convert uint16_t return distance to double. [meters]
+ *
+ */
+#define VELO_HDL32E_DISTANCE_TO_METER( mrange ) ((((double) mrange) * 0.002))
+
+
+
+
+// enforce 1 byte alignment so we can do linear packing
+#pragma pack(push)
+#pragma pack(1)
+
+
+/**
+ * @brief Velodyne HDL laser return data.
+ *
+ * Provides laser return distance and intensity information.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    uint16_t distance; /*!< Distance.
+                        * Value \ref VELO_HDL_LASER_RETURN_DISTANCE_INVALID means invalid laser return. [2 millimeters/bit] */
+    //
+    //
+    uint8_t intensity; /*!< Intensity. See \ref VELO_HDL_LASER_RETURN_INTENSITY_MIN and \ref VELO_HDL_LASER_RETURN_INTENSITY_MAX. */
+} velodyne_hdl_laser_return_s;
+
+
+/**
+ * @brief Velodyne HDL firing data.
+ *
+ * Provides a block of vertical laser return information for a rotation angle.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    uint16_t block_id; /*!< Block idetifier. Identifies the information block.
+                        * See \ref VELO_HDL_BLOCK_ID_0_TO_31 and \ref VELO_HDL_BLOCK_ID_32_TO_63 for valid values. */
+    //
+    //
+    uint16_t rotational_pos; /*!< Rotation angle. [1/100 degrees/bit] */
+    //
+    //
+    velodyne_hdl_laser_return_s laser_returns[VELO_HDL_LASER_PER_FIRING]; /*!< Laser returns. */
+} velodyne_hdl_firing_data_s;
+
+
+
+/**
+ * @brief Velodyne HDL message data.
+ *
+ * Provides a list of firing data blocks and timing information.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    velodyne_hdl_firing_data_s firing_data[VELO_HDL32E_FIRING_PER_MESSAGE]; /*!< Firing data blocks. */
+    //
+    //
+    uint32_t gps_timestamp; /*!< GPS synchronized timestamp. Time since the top of the hour. [microseconds] */
+    //
+    //
+    uint8_t reserved_0; /*!< Reserved data. */
+    //
+    //
+    uint8_t reserved_1; /*!< Reserved data. */
+} velodyne_hdl_message_s;
+
+
+// restore alignment
+#pragma pack(pop)
+
+
+/**
+ * @brief Velodyne HDL32E laser correction data.
+ *
+ * Contains pre-calculated laser correction data.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    double azimuth; /*!< Azimuth. */
+    //
+    //
+    double vertical; /*!< Vertical. [degrees] */
+    //
+    //
+    double distance; /*!< Distance. */
+    //
+    //
+    double vertical_offset; /*!< Vertical offset. */
+    //
+    //
+    double horizontal_offset; /*!< Horizontal offset. */
+    //
+    //
+    double sin_vertical; /*!< Sine vertical. */
+    //
+    //
+    double cos_vertical; /*!< Cosine vertical. */
+    //
+    //
+    double sin_vertical_offset; /*!< Sine vertical offset. */
+    //
+    //
+    double cos_vertical_offset; /*!< Cosine vertical offset. */
+} velodyne_hdl32e_laser_correction_s;
+
+
+/**
+ * @brief Velodyne HDL32E corrections data.
+ *
+ */
+typedef struct
+{
+    //
+    //
+    velodyne_hdl32e_laser_correction_s laser_corrections[VELO_HDL_LASERS_MAX]; /*!< Correction for each laser. */
+    //
+    //
+    double cos_table[VELO_HDL_ROTATION_ANGLE_COUNT]; /*!< Lookup table for cosine(rotational_position) . */
+    //
+    //
+    double sin_table[VELO_HDL_ROTATION_ANGLE_COUNT]; /*!< Lookup table for sine(rotational_position) . */
+} velodyne_hdl32e_corrections_s;
+
+
+
+
+/**
+ * @brief Initialize Velodyne HDL32E corrections data using an array of vertical corrections.
+ *
+ * @param [in] laser_vertical_corrections A pointer to double which specifies the input vertical corrections array.
+ * @param [in] num_lasers Number of vertical corrections/lasers in the provided array.
+ * @param [out] corrections A pointer to \ref velodyne_hdl32e_corrections_s which receives the initialization.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ *
+ */
+int velodyne_hdl32e_init_corrections(
+        const double * const laser_vertical_corrections,
+        const unsigned long num_lasers,
+        velodyne_hdl32e_corrections_s * const corrections );
+
+
+/**
+ * @brief Configure UDP socket for Velodyne HDL device communication.
+ *
+ * @note Expects a valid TCP socket, created by the user.
+ *
+ * @note Sets the non-blocking IO socket option.
+ *
+ * @param [in] sock A pointer to \ref ps_socket which receives the configuration.
+ * @param [in] address A pointer to char buffer which specifies the device IP address.
+ * Value \ref PSYNC_SOCKET_ADDRESS_ANY is acceptable but not recommended.
+ * @parm [in] port Port number to bind the socket to.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if success.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_CONFIG if socket/configuration is invalid.
+ *
+ */
+int velodyne_hdl_configure_socket(
+        ps_socket * const sock,
+        const char * const address,
+        const unsigned long port );
+
+
+/**
+ * @brief Check if byte buffer is a valid Velodyne HDL message.
+ *
+ * Checks for a valid buffer size.
+ *
+ * @param [in] buffer A pointer to char buffer which receives the validation.
+ * @param [in] buffer_len Number of bytes in the buffer. [bytes]
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_DATAERR if message is invalid.
+ *
+ */
+int velodyne_hdl_is_message_valid(
+        const unsigned char * const buffer,
+        const unsigned long buffer_len );
+
+
+/**
+ * @brief Check if data is a valid Velodyne HDL firing data.
+ *
+ * Checks for a valid block ID and firing rotation position.
+ *
+ * @param [in] firing_data A pointer to \ref velodyne_hdl_firing_data_s which receives the validation.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_DATAERR if data is invalid.
+ *
+ */
+int velodyne_hdl_is_firing_data_valid(
+        const velodyne_hdl_firing_data_s * const firing_data );
+
+
+/**
+ * @brief Check if data is a valid Velodyne HDL laser return.
+ *
+ * Checks for a valid return distance.
+ *
+ * @param [in] laser_return A pointer to \ref velodyne_hdl_laser_return_s which receives the validation.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_DATAERR if data is invalid.
+ *
+ */
+int velodyne_hdl_is_laser_return_valid(
+        const velodyne_hdl_laser_return_s * const laser_return );
+
+
+/**
+ * @brief Poll for an available valid Velodyne HDL message.
+ *
+ * Calls \ref velodyne_hdl_is_message_valid if a frame was received.
+ *
+ * @param [in] sock A pointer to \ref ps_socket which holds the configuration.
+ * @param [out] buffer A pointer to unsigned char buffer which receives the data read.
+ * @param [in] buffer_len Length of provided buffer.
+ * @param [out] bytes_read A pointer to unsigned long which receives the count value.
+ * @param [out] timestamp A pointer to \ref ps_timestamp which receives the receive timestamp value.
+ *
+ * @return DTC code:
+ * \li \ref DTC_NONE (zero) if frame is valid.
+ * \li \ref DTC_USAGE if arguments invalid.
+ * \li \ref DTC_UNAVAILABLE if timeout expired and/or no message available when in non-blocking mode (see \ref psync_socket_recv_from).
+ * \li \ref DTC_DATAERR if frame is invalid.
+ *
+ */
+int velodyne_hdl_read_message(
+        ps_socket * const sock,
+        unsigned char * const buffer,
+        const unsigned long buffer_len,
+        unsigned long * const bytes_read,
+        ps_timestamp * const timestamp );
+
+
+
+
+#endif	/* VELODYNE_HDL_DRIVER_H */

--- a/logfile_to_pcap_convertor/src/logfile_to_pcap_convertor.c
+++ b/logfile_to_pcap_convertor/src/logfile_to_pcap_convertor.c
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2016 HARBRICK TECHNOLOGIES, INC
+ *
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * \example logfile_iterator.c
+ *
+ * Shows how to use the Logfile API routines to iterate over a Velodyne HDL
+ * PolySync logfile (.plog file), outside the normal replay time domain.
+ * 
+ * Note: PCAP must be installed to the system: `apt-get install pcaputils`
+ *
+ */
+
+
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+#include <pcap/pcap.h>
+#include <net/ethernet.h>
+
+// API headers
+#include "polysync_core.h"
+#include "polysync_sdf.h"
+#include "polysync_node.h"
+#include "polysync_message.h"
+#include "polysync_logfile.h"
+
+#include "velodyne_hdl_driver.h"
+
+
+
+
+// *****************************************************
+// static global types/macros
+// *****************************************************
+
+//
+typedef struct
+{
+    //
+    // node reference
+    ps_node_ref node_ref;
+    //
+    // message type for 'ps_byte_array_msg'
+    ps_msg_type byte_array_msg_type;
+    //
+    // pcap handle
+    pcap_t *pcap;
+    //
+    // pcap buffer
+    pcap_dumper_t *dumper;
+    //
+    //
+    char in_file[PSYNC_DEFAULT_STRING_LEN];
+    //
+    //
+    char out_file[PSYNC_DEFAULT_STRING_LEN];
+} context_s;
+
+
+
+
+// *****************************************************
+// static global data
+// *****************************************************
+
+/**
+ * @brief PolySync node name.
+ *
+ */
+static const char NODE_NAME[] = "velodyne-logfile-to-pcap";
+
+
+/**
+ * @brief PolySync 'ps_byte_array_msg' type name, which is where the Velodyne
+ * data is stored within the .plog file.
+ *
+ */
+static const char BYTE_ARRAY_MSG_NAME[] = "ps_byte_array_msg";
+
+
+static unsigned char *global_buffer = NULL;
+static unsigned long global_buffer_size = 0;
+
+
+
+
+// *****************************************************
+// static declarations
+// *****************************************************
+
+/**
+ * @brief Logfile iterator callback.
+ *
+ * @warning When logfile is empty, expect:
+ * \li \ref ps_logfile_attributes.data_count == 0
+ * \li msg_type == \ref PSYNC_MSG_TYPE_INVALID
+ * \li log_record == NULL
+ *
+ * @param [in] file_attributes Logfile attributes loaded by the logfile API.
+ * @param [in] msg_type Message type identifier for the message in \ref ps_rnr_log_record.data, as seen by this data model.
+ * @param [in] log_record Logfile record loaded by the logfile API.
+ * @param [in] user_data A pointer to user data, provided by \ref psync_logfile_foreach_iterator.
+ *
+ */
+static void logfile_iterator_callback(
+        const ps_logfile_attributes * const file_attributes,
+        const ps_msg_type msg_type,
+        const ps_rnr_log_record * const log_record,
+        void * const user_data );
+
+
+
+
+// *****************************************************
+// static definitions
+// *****************************************************
+
+//
+static int resize_global_buffer( const unsigned long size )
+{
+    int ret = DTC_NONE;
+
+
+    if( size > global_buffer_size )
+    {
+        global_buffer = realloc( global_buffer, size * sizeof(*global_buffer) );
+        if( global_buffer == NULL )
+        {
+            printf( "failed to allocate buffer\n" );
+            ret = DTC_MEMERR;
+        }
+
+        global_buffer_size = size;
+    }
+
+
+    return ret;
+}
+
+
+//
+static void logfile_iterator_callback(
+        const ps_logfile_attributes * const file_attributes,
+        const ps_msg_type msg_type,
+        const ps_rnr_log_record * const log_record,
+        void * const user_data )
+{
+    context_s * const context = (context_s*) user_data;
+
+    // ignore if we don't have any context
+    if( context == NULL )
+    {
+        return;
+    }
+
+    // if logfile is empty, only attributes are provided
+    if( log_record != NULL )
+    {
+        // get the PolySync message reference
+        const ps_msg_ref msg = (ps_msg_ref) log_record->data;
+
+        // 'ps_byte_array_msg' type is where the Velodyne data payload is stored
+        // within the .plog file
+        if( msg_type == context->byte_array_msg_type )
+        {
+            // UDP velodyne packet header
+            // this must exist in the PCAP file in order for Velodyne's Veloview 
+            // to visualize the data
+            const unsigned char udp_header[] =
+            {
+                0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x60, 0x76,
+                0x88, 0x20, 0x11, 0x8C, 0x08, 0x00, 0x45, 0x00,
+                0x04, 0xD2, 0x00, 0x00, 0x40, 0x00, 0xFF, 0x11,
+                0xB4, 0xA9, 0xC0, 0xA8, 0x01, 0xC9, 0xFF, 0xFF,
+                0xFF, 0xFF, 0x09, 0x40, 0x09, 0x40, 0x04, 0xBE,
+                0x00, 0x00
+            };
+
+            //
+            const ps_byte_array_msg * const byte_array_msg = (ps_byte_array_msg*) msg;
+
+            //
+            (void) resize_global_buffer( byte_array_msg->bytes._length + sizeof(udp_header) );
+
+            // copy UDP header
+            memcpy( global_buffer, udp_header, sizeof(udp_header) );
+
+            // copy payload
+            memcpy( &global_buffer[ sizeof(udp_header) ], (char*) byte_array_msg->bytes._buffer, (unsigned long) byte_array_msg->bytes._length );
+
+            // create the pcap header
+            struct pcap_pkthdr pcap_header;
+
+            memset( &pcap_header, 0, sizeof(pcap_header) );
+
+            // must set the pcap header values to create a valid packet
+            pcap_header.caplen = (bpf_u_int32) byte_array_msg->bytes._length + sizeof(udp_header);
+            pcap_header.len = pcap_header.caplen;
+
+            // UTC micro second to struct timeval (second.microsecond)
+            pcap_header.ts.tv_sec = byte_array_msg->header.timestamp / 1000000;
+            pcap_header.ts.tv_usec = (byte_array_msg->header.timestamp % 1000000);
+
+            // write
+            pcap_dump( (u_char*) context->dumper, &pcap_header, (u_char*) global_buffer );
+        }
+    }
+}
+
+
+
+
+// *****************************************************
+// main
+// *****************************************************
+int main( int argc, char **argv )
+{
+    // polysync return status
+    int ret = DTC_NONE;
+
+    // context data
+    context_s context;
+
+
+    memset( &context, 0, sizeof(context) );
+
+    // first argument in input file path, output file path is (IN).pcap
+    if( (argc == 2) && (strlen(argv[1]) > 0) )
+    {
+        strncpy( context.in_file, argv[1], sizeof(context.in_file) );
+        snprintf( context.out_file, sizeof(context.out_file) , "%s.pcap", context.in_file );
+    }
+    else
+    {
+        printf( "usage\n$program <input_file>.plog\n" );
+        return EXIT_FAILURE;
+    }
+
+    printf( "\n\n" );
+    printf( "input file: '%s'\n", context.in_file );
+    printf( "output file: '%s'\n", context.out_file );
+    printf( "\n" );
+
+    //
+    context.pcap = pcap_open_dead( DLT_EN10MB, 65535 );
+
+    //
+    context.dumper = pcap_dump_open( context.pcap, context.out_file );
+
+    // init core API
+    ret = psync_init(
+            NODE_NAME,
+            PSYNC_NODE_TYPE_API_USER,
+            PSYNC_DEFAULT_DOMAIN,
+            PSYNC_SDF_ID_INVALID,
+            PSYNC_INIT_FLAG_STDOUT_LOGGING,
+            &context.node_ref );
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_init - ret: %d", ret );
+        (void) psync_release( &context.node_ref );
+        return EXIT_FAILURE;
+    }
+
+    // get the message type for 'ps_byte_array_msg'
+    ret = psync_message_get_type_by_name(
+            context.node_ref,
+            BYTE_ARRAY_MSG_NAME,
+            &context.byte_array_msg_type );
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_message_get_type_by_name - ret: %d", ret );
+        (void) psync_release( &context.node_ref );
+        return EXIT_FAILURE;
+    }
+
+    ps_msg_ref msg = NULL;
+    ps_msg_type type = 0;
+    (void) psync_message_get_type_by_name( context.node_ref, "ps_rnr_msg", &type );
+    (void) psync_message_alloc( context.node_ref, type, &msg );
+    (void) psync_message_publish( context.node_ref, msg );
+
+    // initialize logfile API resources
+    ret = psync_logfile_init( context.node_ref );
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_logfile_init - ret: %d", ret );
+        (void) psync_release( &context.node_ref );
+        return EXIT_FAILURE;
+    }
+
+    // iterate over the logfile data, which executes the callback function for
+    // each record in the .plog file
+    ret = psync_logfile_foreach_iterator(
+            context.node_ref,
+            context.in_file,
+            logfile_iterator_callback,
+            &context );
+
+    if( global_buffer != NULL )
+    {
+        free( global_buffer );
+        global_buffer = NULL;
+    }
+
+    if( context.dumper != NULL )
+    {
+        pcap_dump_close( context.dumper );
+    }
+
+    if( context.pcap != NULL )
+    {
+        pcap_close( context.pcap );
+    }
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_logfile_foreach_iterator - ret: %d", ret );
+        (void) psync_release( &context.node_ref );
+        return EXIT_FAILURE;
+    }
+
+    // release logfile API resources
+    ret = psync_logfile_release( context.node_ref );
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_logfile_release - ret: %d", ret );
+        (void) psync_release( &context.node_ref );
+        return EXIT_FAILURE;
+    }
+
+    // release core API
+    ret = psync_release( &context.node_ref );
+
+    if( ret != DTC_NONE )
+    {
+        psync_log_error( "psync_release - ret: %d", ret );
+        return EXIT_FAILURE;
+    }
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
PS logfile to pcap file type convertor tool. This is a great practicle example of the logfile iterator. The application converts a PS plog file to a pcap file capable of being played in Velodyne's Veloview application.

Logfile iterator for the Velodyne HDL, which shows how to cast to the appropriate data strcutres, and access the sensors raw data.
