### PR TITLE
Replace outdated reference to util.h

### DIFF
--- a/phidget_spatial_dynamic_driver_interface/interfaces/example/src/interface.c
+++ b/phidget_spatial_dynamic_driver_interface/interfaces/example/src/interface.c
@@ -27,7 +27,7 @@
 #include "polysync_core.h"
 #include "polysync_node.h"
 #include "polysync_sdf.h"
-#include "util.h"
+#include "polysync_interface_util.h"
 #include "polysync_dynamic_interface.h"
 
 


### PR DESCRIPTION
Prior to this commit, the file included util.h which is a deprecated
file that has been replaced by polysync_interface_util.h. This commit
changes the file to include polysync_interface_util.h.