### PR TITLE
Add documentation / instructions to udm idl file.

### DIFF
--- a/user_data_model/idl/user_data_model.idl
+++ b/user_data_model/idl/user_data_model.idl
@@ -3,6 +3,12 @@
  * @brief PolySync User Data Model Example Module.
  *
  * Notes:
+ * 
+ * When used to generate a C++ API( with the '-c' flag), the tool polysync-pdm-gen
+ * will camel case types defined here. To avoid name collisions in C and C++ APIs 
+ * prefer snake case in this file, i.e. 'my_custom_type'. If a type defined here 
+ * uses camel case, i.e. 'MyCustomType' to avoid collisions the generated symbol 
+ * will have '_cpp' appended to it, as in 'MyCustomType_cpp'.
  *
  * Three global constants are required for all IDL data model modules and they 
  * must correspond directly with the IDL file name. 

--- a/user_data_model/idl/user_data_model.idl
+++ b/user_data_model/idl/user_data_model.idl
@@ -6,9 +6,9 @@
  * 
  * When used to generate a C++ API( with the '-c' flag), the tool polysync-pdm-gen
  * will camel case types defined here. To avoid name collisions in C and C++ APIs 
- * prefer snake case in this file, i.e. 'my_custom_type'. If a type defined here 
- * uses camel case, i.e. 'MyCustomType' to avoid collisions the generated symbol 
- * will have '_cpp' appended to it, as in 'MyCustomType_cpp'.
+ * the tool prefers snake case in the IDL files, i.e. 'my_custom_type'. 
+ * If a type defined here uses camel case, i.e. 'MyCustomType', the generated symbol 
+ * will have '_cpp' appended to it to avoid collisions. For example 'MyCustomType_cpp'.
  *
  * Three global constants are required for all IDL data model modules and they 
  * must correspond directly with the IDL file name. 


### PR DESCRIPTION
Prior to this commit the idl file in the udm example
had no indication of the snake v camel case requirements.

After this commit this requirement is expressed and the name
mangling that a collision causes is noted.