### PR TITLE
User data model Makefile changes for 2.0

### DIFF
--- a/user_data_model/Makefile
+++ b/user_data_model/Makefile
@@ -61,7 +61,7 @@ $(DEPS): %.dep: %.c Makefile
 
 # add our example module to the complete data model
 build-pdm:
-	$(PSYNC_HOME)/bin/pdm-gen \
+	$(PSYNC_HOME)/bin/pdm-gen -c \
 	$(PSYNC_HOME)/modules/dtc/dtc.idl \
 	$(PSYNC_HOME)/modules/sensor/sensor.idl \
 	$(PSYNC_HOME)/modules/navigation/navigation.idl \
@@ -72,16 +72,16 @@ build-pdm:
 
 # install our example data model into the system
 install-pdm:
-	cp pdm/*.so $(PSYNC_HOME)/lib/
-	cp pdm/*.h $(PSYNC_HOME)/pdm/
-	cp pdm/*.hpp $(PSYNC_HOME)/pdm/
+	sudo cp -a pdm/*.so* /usr/lib/
+	sudo cp pdm/*.h $(PSYNC_HOME)/pdm/
+	sudo cp pdm/*.hpp $(PSYNC_HOME)/pdm/
 
 # install to system
 install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-	cp pdm/*.so $(PSYNC_HOME)/lib/
-	cp pdm/*.h $(PSYNC_HOME)/pdm/
-	cp pdm/*.hpp $(PSYNC_HOME)/pdm/
+	sudo cp $(TARGET) $(PSYNC_HOME)/bin/
+	sudo cp -a pdm/*.so* /usr/lib/
+	sudo cp pdm/*.h $(PSYNC_HOME)/pdm/
+	sudo cp pdm/*.hpp $(PSYNC_HOME)/pdm/
 
 #
 clean:


### PR DESCRIPTION
Prior to this commit the user data model example did not reflect the
state of a polysync install under version 2.0. After this commit it
will. polysync data model libs now live in `/usr/lib` and need to
be installed there with `sudo`. Installing the rest of the artifacts to
`/usr/local/polysync` also now requires `sudo`. The CPP api is no
longer generated by default, a `-c` flag must be passed to pdm-gen
to enable it and that flag was added to the generation step in
the Makefile.