### PR TITLE
Add libpng12-dev to parrot-visualizer deps list

### DIFF
--- a/parrot_visualizer/README.md
+++ b/parrot_visualizer/README.md
@@ -10,7 +10,7 @@ For more detailed information, look at the [Vehicle Control Tutorial](https://he
 
 ### Dependencies
 
-Packages: libglib2.0-dev freeglut3-dev libsdl2-dev libsdl2-image-dev
+Packages: libglib2.0-dev freeglut3-dev libsdl2-dev libsdl2-image-dev libpng12-dev
 
 To install on Ubuntu: 
 


### PR DESCRIPTION
Prior to this commit, the example would not build because it was
missing the "png.h" header. This commit adds the libpng12-dev
dependency which includes the header.