### PR TITLE
Remove 'make install' target

### DIFF
--- a/can_reader/Makefile
+++ b/can_reader/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/can_writer/Makefile
+++ b/can_writer/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/data_generator/Makefile
+++ b/data_generator/Makefile
@@ -58,10 +58,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/enumerate_dynamic_drivers/Makefile
+++ b/enumerate_dynamic_drivers/Makefile
@@ -55,10 +55,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/get_set/Makefile
+++ b/get_set/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/image_data_viewer/Makefile
+++ b/image_data_viewer/Makefile
@@ -59,10 +59,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/joystick_commander/Makefile
+++ b/joystick_commander/Makefile
@@ -61,10 +61,6 @@ dirs::
 	mkdir -p bin
 	mkdir -p doc/html
 
-# install to system
-install: all
-	-cp $(TARGET) $(PSYNC_HOME)/bin/
-
 # clean
 clean::
 	rm -f src/*.o

--- a/logfile_iterator/Makefile
+++ b/logfile_iterator/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/logfile_iterator_for_velodyne/Makefile
+++ b/logfile_iterator_for_velodyne/Makefile
@@ -55,10 +55,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/logfile_queue_reader/Makefile
+++ b/logfile_queue_reader/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/logfile_reader/Makefile
+++ b/logfile_reader/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/logfile_to_pcap_convertor/Makefile
+++ b/logfile_to_pcap_convertor/Makefile
@@ -55,10 +55,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/logfile_writer/Makefile
+++ b/logfile_writer/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/node_template/Makefile
+++ b/node_template/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/phidget_spatial_dynamic_driver_interface/drivers/phidget_spatial/Makefile
+++ b/phidget_spatial_dynamic_driver_interface/drivers/phidget_spatial/Makefile
@@ -73,10 +73,6 @@ dirs::
 	mkdir -p $(BUILD_DIR)/bin
 	mkdir -p $(LIB_DIR)
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/lib/
-
 # tests
 test:: dirs
 	$(CC) $(CCFLAGS) $(INCLUDE) -I$(BUILD_HOME)/tests/tools -o $(TEST_INTERFACE_TARGET) src/phidget_spatial_test_interface.c $(TARGET) $(LIBS) -lphidget21

--- a/phidget_spatial_dynamic_driver_interface/interfaces/example/Makefile
+++ b/phidget_spatial_dynamic_driver_interface/interfaces/example/Makefile
@@ -93,10 +93,6 @@ $(DEPS): %.dep: %.c Makefile
 dirs::
 	mkdir -p $(LIB_DIR)
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/lib/
-
 # clean
 clean::
 	rm -f src/*.o

--- a/phidget_spatial_dynamic_driver_interface/interfaces/phidget_spatial/Makefile
+++ b/phidget_spatial_dynamic_driver_interface/interfaces/phidget_spatial/Makefile
@@ -125,10 +125,6 @@ $(DEPS): %.dep: %.c Makefile
 dirs::
 	mkdir -p $(LIB_DIR)
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/lib/
-
 # clean
 clean::
 	rm -f src/*.o

--- a/publish_subscribe/Makefile
+++ b/publish_subscribe/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/rnr_control/Makefile
+++ b/rnr_control/Makefile
@@ -49,10 +49,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/rnr_node/Makefile
+++ b/rnr_node/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/serial_reader/Makefile
+++ b/serial_reader/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/serial_writer/Makefile
+++ b/serial_writer/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/sharedmem_image_data_viewer/Makefile
+++ b/sharedmem_image_data_viewer/Makefile
@@ -59,10 +59,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/single_transform/Makefile
+++ b/single_transform/Makefile
@@ -49,10 +49,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/socket_reader/Makefile
+++ b/socket_reader/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/socket_writer/Makefile
+++ b/socket_writer/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/transform_stack/Makefile
+++ b/transform_stack/Makefile
@@ -49,10 +49,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/user_data_model/Makefile
+++ b/user_data_model/Makefile
@@ -67,21 +67,9 @@ build-pdm:
 	$(PSYNC_HOME)/modules/navigation/navigation.idl \
 	$(PSYNC_HOME)/modules/control/control.idl \
 	idl/user_data_model.idl > pdm/version.txt
+
 # show the results
 	cat pdm/error.log
-
-# install our example data model into the system
-install-pdm:
-	sudo cp -a pdm/*.so* /usr/lib/
-	sudo cp pdm/*.h $(PSYNC_HOME)/pdm/
-	sudo cp pdm/*.hpp $(PSYNC_HOME)/pdm/
-
-# install to system
-install: all
-	sudo cp $(TARGET) $(PSYNC_HOME)/bin/
-	sudo cp -a pdm/*.so* /usr/lib/
-	sudo cp pdm/*.h $(PSYNC_HOME)/pdm/
-	sudo cp pdm/*.hpp $(PSYNC_HOME)/pdm/
 
 #
 clean:

--- a/video_encode_decode/Makefile
+++ b/video_encode_decode/Makefile
@@ -52,10 +52,6 @@ $(OBJS): %.o: %.c %.dep
 $(DEPS): %.dep: %.c Makefile
 	$(CC) $(CCFLAGS) $(INCLUDE) -MM $< > $@
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o

--- a/viewer_lite/Makefile
+++ b/viewer_lite/Makefile
@@ -74,10 +74,6 @@ $(DEPS): %.dep: %.c Makefile
 docs: dirs
 	cd doc && doxygen Doxyfile;
 
-# install to system
-install: all
-	cp $(TARGET) $(PSYNC_HOME)/bin/
-
 #
 clean:
 	-rm -f src/*.o


### PR DESCRIPTION
Prior to this commit, the Makefiles had an 'install' target which would
attempt to install their binaries into $PSYNC_HOME/bin, which is owned
by root:root and should not be polluted with examples. This commit
removes those install targets.