### PR TITLE
Replace package placeholder with actual dependencies

### DIFF
--- a/can_reader/README.md
+++ b/can_reader/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/can_writer/README.md
+++ b/can_writer/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/data_generator/README.md
+++ b/data_generator/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/enumerate_dynamic_drivers/README.md
+++ b/enumerate_dynamic_drivers/README.md
@@ -10,7 +10,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/get_set/README.md
+++ b/get_set/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/image_data_viewer/README.md
+++ b/image_data_viewer/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev freeglut3-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev freeglut3-dev
 ```
 
 ### Building and running the node

--- a/joystick_commander/README.md
+++ b/joystick_commander/README.md
@@ -18,7 +18,7 @@ Packages: libglib2.0-dev libsdl2-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev libsdl2-dev
 ```
 
 ### Building and running the node

--- a/logfile_iterator/README.md
+++ b/logfile_iterator/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/logfile_iterator_for_velodyne/README.md
+++ b/logfile_iterator_for_velodyne/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/logfile_queue_reader/README.md
+++ b/logfile_queue_reader/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/logfile_reader/README.md
+++ b/logfile_reader/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/logfile_to_pcap_convertor/README.md
+++ b/logfile_to_pcap_convertor/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev libpcap-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev libpcap-dev
 ```
 
 ### Building and running the node

--- a/logfile_writer/README.md
+++ b/logfile_writer/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/node_template/README.md
+++ b/node_template/README.md
@@ -18,7 +18,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/parrot_controller/README.md
+++ b/parrot_controller/README.md
@@ -13,7 +13,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/parrot_visualizer/README.md
+++ b/parrot_visualizer/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev freeglut3-dev libsdl2-dev libsdl2-image-dev libpng12-de
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev freeglut3-dev libsdl2-dev libsdl2-image-dev libpng12-dev
 ```
 
 ### Building and running the node

--- a/phidget_spatial_dynamic_driver_interface/README.md
+++ b/phidget_spatial_dynamic_driver_interface/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev libusb-1.0-0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev libusb-1.0-0-dev
 ```
 Install the Phidget libraries by following these instructions: http://www.phidgets.com/docs/OS_-_Linux#Installing
 

--- a/publish_subscribe/README.md
+++ b/publish_subscribe/README.md
@@ -13,7 +13,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/rnr_control/README.md
+++ b/rnr_control/README.md
@@ -29,7 +29,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/rnr_node/README.md
+++ b/rnr_node/README.md
@@ -15,7 +15,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/serial_reader/README.md
+++ b/serial_reader/README.md
@@ -14,7 +14,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/serial_writer/README.md
+++ b/serial_writer/README.md
@@ -13,7 +13,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/sharedmem_image_data_viewer/README.md
+++ b/sharedmem_image_data_viewer/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev freeglut3-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev freeglut3-dev
 ```
 
 ### Building and running the node

--- a/single_transform/README.md
+++ b/single_transform/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev freeglut3-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev freeglut3-dev
 ```
 
 ### Building and running the node

--- a/socket_reader/README.md
+++ b/socket_reader/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/socket_writer/README.md
+++ b/socket_writer/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the mode

--- a/transform_stack/README.md
+++ b/transform_stack/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/user_data_model/README.md
+++ b/user_data_model/README.md
@@ -11,7 +11,7 @@ Packages: libglib2.0-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev
 ```
 
 ### Building and running the node

--- a/video_encode_decode/README.md
+++ b/video_encode_decode/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev libgstreamer1.0-0
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev libgstreamer1.0-0
 ```
 
 ### Building and running the node

--- a/viewer_lite/README.md
+++ b/viewer_lite/README.md
@@ -17,7 +17,7 @@ Packages: libglib2.0-dev freeglut3-dev
 To install on Ubuntu: 
 
 ```bash
-sudo apt-get install <package>
+sudo apt-get install libglib2.0-dev freeglut3-dev
 ```
 
 ### Building and running the node


### PR DESCRIPTION
Prior to this commit users had to replace the package placeholder
every time they ran Core C and Core CPP examples. This commit
eliminates this hassle.